### PR TITLE
Direct Link Display fixing timezone

### DIFF
--- a/Neopets - Direct Link Display.user.js
+++ b/Neopets - Direct Link Display.user.js
@@ -103,7 +103,7 @@ if(url.includes("/process_cocoshy.phtml")) {
 })()
 
 function getTime(date = new Date(), zeroTime = false) {
-    let d = date.toLocaleString("en-US", {timeZone: "PST"}).split(",")
+    let d = date.toLocaleString("en-US", {timeZone: "America/Los_Angeles"}).split(",")
     if(zeroTime) return {date: d[0].trim(), time: "12:00:00 AM NST"}
     else return {date: d[0].trim(), time: d[1].trim()+" NST"}
 }


### PR DESCRIPTION
Fixing timezone.

This was breaking for me in firefox with the error

`Uncaught (in promise) RangeError: invalid time zone in DateTimeFormat(): PST`