### PR TITLE
Fix timezone bug in getDate()

### DIFF
--- a/Neopets - Battledome Set Selector.user.js
+++ b/Neopets - Battledome Set Selector.user.js
@@ -1418,7 +1418,7 @@ function clone(data) {
 }
 
 function getDate() {
-    return new Date().toLocaleString("en-US", {timeZone: "PST"}).slice(0, 10).replace(",","")
+    return new Date().toLocaleString("en-US", {timeZone: "America/Los_Angeles"}).slice(0, 10).replace(",","")
 }
 
 function getItemURL(node, ability=false) {


### PR DESCRIPTION
Use of "PST" is problematic as it doesn't work during "PDT". Switched to the daylight savings time neutral "America/Los_Angeles" instead.

I fixed this in my local copy but figured I could PR against yours for the sake of others :)